### PR TITLE
fix: added types property in on.release

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -2,7 +2,8 @@ name: Deploy prod
 
 on:
   release:
-    - published
+    types: 
+      - published
 
 jobs:
   upload-release-assets:


### PR DESCRIPTION
Added missing `types:` part which caused the workflow to fail due to bad syntax.