### PR TITLE
feat: change hardcoded org to github context

### DIFF
--- a/.github/workflows/hotfix-created.yml
+++ b/.github/workflows/hotfix-created.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           app-id: ${{ secrets.GHAPP_APP_DEPLOYER_APP_ID }}
           private-key: ${{ secrets.GHAPP_APP_DEPLOYER_PRIVATE_KEY }}
-          owner: Verweij-IT
+          owner: ${{ github.event.organization.login }}
 
       - name: Trim of hot from branch ref
         id: trim-branch

--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           app-id: ${{ secrets.GHAPP_APP_DEPLOYER_APP_ID }}
           private-key: ${{ secrets.GHAPP_APP_DEPLOYER_PRIVATE_KEY }}
-          owner: Verweij-IT
+          owner: ${{ github.event.organization.login }}
   
       - name: Run release-please
         id: release-please
@@ -63,7 +63,7 @@ jobs:
         with:
           app-id: ${{ secrets.GHAPP_APP_DEPLOYER_APP_ID }}
           private-key: ${{ secrets.GHAPP_APP_DEPLOYER_PRIVATE_KEY }}
-          owner: Verweij-IT
+          owner: ${{ github.event.organization.login }}
       
       - name: Install semver package
         run: |


### PR DESCRIPTION
Changing hard-coded `Verweij-IT` organization to GitHub context. This also makes it easier to copy this over to other organizations.  